### PR TITLE
fix array destructuring

### DIFF
--- a/modules/item-track.js
+++ b/modules/item-track.js
@@ -64,7 +64,7 @@ export default class ItemTrack {
         const sceneTokenId = itemCard.attr("data-token-id");
 
         if (sceneTokenId) {
-            const [sceneId, tokenId] = sceneTokenId.split(".");
+            const [, sceneId, , tokenId] = sceneTokenId.split(".");
             const token = canvas.scene.id === sceneId ? canvas.tokens.get(tokenId) : game.scenes.get(sceneId)?.data.tokens.find(t => t._id === tokenId);
             item = token.actor.getOwnedItem(itemId);
         } else if (!sceneTokenId && actorId) {


### PR DESCRIPTION
Splitting `sceneTokenId` results in ["Scene", "Scene_id", "Token", "Token_id"] so it was previously assigning "Scene" to `sceneId` and "Scene_id" to `tokenId`, resulting in an undefined `token`.