### PR TITLE
Don't play Hypetrack before combat begins

### DIFF
--- a/modules/hype-track.js
+++ b/modules/hype-track.js
@@ -60,7 +60,7 @@ export default class HypeTrack {
      * @param {*} update - the update data
      */
     async _processHype(combat, update) {
-        if (!Number.isNumeric(update.turn) || !combat.combatants?.contents?.length || !this.playlist || !game.user.isGM) {
+        if (combat?.current?.round == 0 || !Number.isNumeric(update.turn) || !combat.combatants?.contents?.length || !this.playlist || !game.user.isGM) {
             return;
         }
 


### PR DESCRIPTION
Edits the ```_processHype``` function to do a quick check of the combat round.

If the combat round is still 0, combat hasn't started yet so ```_processHype``` should return without starting any music.