### PR TITLE
Update module manifest to foundry v10

### DIFF
--- a/module.json
+++ b/module.json
@@ -14,6 +14,11 @@
     }
   ],
   "version":"0.9.0",
+  "compatibility":{
+    "minimum": "10",
+    "verified": "10",
+    "maximum": "10"
+  },
   "minimumCoreVersion":"10.278",
   "compatibleCoreVersion":"10.278",
   "esmodules":["./maestro.js"],

--- a/module.json
+++ b/module.json
@@ -1,4 +1,5 @@
 {
+  "id":"maestro",
   "name":"maestro",
   "title":"Maestro",
   "description":"Adds new sound-related features such as Hype Tracks and Item Tracks",
@@ -34,7 +35,7 @@
       "path": "lang/ko.json"
     },
     {
-      "lang": "pt-BR", 
+      "lang": "pt-BR",
       "name": "Português (Brasil)",
       "path": "lang/pt-BR.json"
     },
@@ -51,4 +52,4 @@
   "flags": {
     "allowBugReporter": true
   }
-}  
+}


### PR DESCRIPTION
The change on compatibility: https://github.com/foundryvtt/foundryvtt/issues/7011

On deprecating name in favor of id https://github.com/foundryvtt/foundryvtt/issues/7009

I've kept the old fields but I think they could be dropped.