### PR TITLE
Add pathfinder 2e system-specific rules for critical and a way to not play sound on blind rolls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -45,6 +45,9 @@
         "SETTINGS.CriticalSuccessFailureTracks.criticalOnBlindRollN": "Play sound on blind roll",
         "SETTINGS.CriticalSuccessFailureTracks.criticalOnBlindRollH": "Play a sound on critical success/failure on blind rolls too",
 
+        "SETTINGS.PF2eSpecific.enableN":"Use pathfinder 2 critical success/failure",
+        "SETTINGS.PF2eSpecific.enableH":"Enable pathfinder 2 system-specific rules to define critical success and failures instead of thresholds",
+
         "SETTINGS.ItemTrack.DeletedItemsN": "Deleted Items",
         "SETTINGS.ItemTrack.DeletedItemsH": "Deleted Item Ids and and their associated Item Tracks",
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -45,7 +45,7 @@
 
         "SETTINGS.ItemTrack.DeletedItemsN": "Deleted Items",
         "SETTINGS.ItemTrack.DeletedItemsH": "Deleted Item Ids and and their associated Item Tracks",
-        
+
         "SETTINGS.Config.ButtonN": "Maestro Config",
         "SETTINGS.Config.ButtonH": "Additional Maestro Settings",
 
@@ -85,8 +85,8 @@
         "LOGS.MigrationTokenOwnedItemsMatched": "Maestro | Matched Item Track in Playlist:",
         "LOGS.MigrationTokenOwnedItemsNotMatched": "Maestro | Unable to match flag to track in Playlist:",
         "LOGS.MigrationTokenOwnedItemFailed": "Maestro | Failed to map Tracks for Token OwnedItems:",
-        "LOGS.MigrationTokenOwnedItemSuccess": "Maestro | Successfully mapped Tracks for Token OwnedItems:", 
-        
+        "LOGS.MigrationTokenOwnedItemSuccess": "Maestro | Successfully mapped Tracks for Token OwnedItems:",
+
         "FORM.PlaylistSelection": "Select a Playlist",
         "FORM.TrackSelection": "Select a Track",
         "FORM.SaveTrack": "Save Track",
@@ -96,7 +96,7 @@
         "FORM.PlayAll": "--Play Playlist--",
 
         "HYPE-TRACK.Form.PlaylistLabel": "Hype Playlist for this Actor",
-        "HYPE-TRACK.Form.TrackLabel": "Track to Play", 
+        "HYPE-TRACK.Form.TrackLabel": "Track to Play",
         "HYPE-TRACK.FormPlaylistTooltip": "Select a Playlist",
         "HYPE-TRACK.FormTrackSelection": "Select a Track",
         "HYPE-TRACK.FormNotes": "Select the audio file to use as this actor's Hype Track",

--- a/lang/en.json
+++ b/lang/en.json
@@ -42,6 +42,8 @@
         "SETTINGS.CriticalSuccessFailureTracks.SuccessThresholdH": "What is the value that a roll must be at or above to critically succeed",
         "SETTINGS.CriticalSuccessFailureTracks.FailureThresholdN": "Failure Threshold",
         "SETTINGS.CriticalSuccessFailureTracks.FailureThresholdH": "What is the value that a roll must be at or below to critically fail",
+        "SETTINGS.CriticalSuccessFailureTracks.criticalOnBlindRollN": "Play sound on blind roll",
+        "SETTINGS.CriticalSuccessFailureTracks.criticalOnBlindRollH": "Play a sound on critical success/failure on blind rolls too",
 
         "SETTINGS.ItemTrack.DeletedItemsN": "Deleted Items",
         "SETTINGS.ItemTrack.DeletedItemsH": "Deleted Item Ids and and their associated Item Tracks",

--- a/maestro.js
+++ b/maestro.js
@@ -8,8 +8,8 @@ import * as Playback from "./modules/playback.js";
 import { registerModuleSettings } from "./modules/settings.js";
 
 /**
- * Orchestrates (pun) module functionality
- */
+* Orchestrates (pun) module functionality
+*/
 export default class Conductor {
     static begin() {
         Conductor._hookOnInit();
@@ -17,8 +17,8 @@ export default class Conductor {
     }
 
     /**
-     * Init Hook
-     */
+    * Init Hook
+    */
     static async _hookOnInit() {
         Hooks.on("init", async () => {
             game.maestro = {};
@@ -28,8 +28,8 @@ export default class Conductor {
     }
 
     /**
-     * Ready Hook
-     */
+    * Ready Hook
+    */
     static async _hookOnReady() {
         Hooks.on("ready", async () => {
             game.maestro.hypeTrack = new HypeTrack();
@@ -62,15 +62,15 @@ export default class Conductor {
     }
 
     /**
-     * Init Hook Registrations
-     */
+    * Init Hook Registrations
+    */
     static _initHookRegistrations() {
         Conductor._hookOnRenderPlaylistDirectory();
     }
 
     /**
-     * Ready Hook Registrations
-     */
+    * Ready Hook Registrations
+    */
     static _readyHookRegistrations() {
         // Sheet/App Render Hooks
         Conductor._hookOnRenderActorSheet();
@@ -96,8 +96,8 @@ export default class Conductor {
     }
 
     /**
-     * PreUpdate Playlist Hook
-     */
+    * PreUpdate Playlist Hook
+    */
     static _hookOnPreUpdatePlaylist() {
         Hooks.on("preUpdatePlaylist", (playlist, update, options, userId) => {
             // unused
@@ -105,8 +105,8 @@ export default class Conductor {
     }
 
     /**
-     * PreUpdate Playlist Sound Hook
-     */
+    * PreUpdate Playlist Sound Hook
+    */
     static _hookOnPreUpdatePlaylistSound() {
         Hooks.on("preUpdatePlaylistSound", (sound, update, options, userId) => {
             Misc._onPreUpdatePlaylistSound(sound, update, options, userId);
@@ -114,8 +114,8 @@ export default class Conductor {
     }
 
     /**
-     * PreCreate Chat Message Hook
-     */
+    * PreCreate Chat Message Hook
+    */
     static _hookOnPreCreateChatMessage() {
         Hooks.on("preCreateChatMessage", (message, options, userId) => {
             Misc._onPreCreateChatMessage(message, options);
@@ -129,8 +129,8 @@ export default class Conductor {
     }
 
     /**
-     * PreUpdate Combat Hook
-     */
+    * PreUpdate Combat Hook
+    */
     static _hookOnPreUpdateCombat() {
         Hooks.on("preUpdateCombat", (combat, update, options, userId) => {
             CombatTrack._onPreUpdateCombat(combat, update, options, userId);
@@ -138,8 +138,8 @@ export default class Conductor {
     }
 
     /**
-     * Update Combat Hook
-     */
+    * Update Combat Hook
+    */
     static _hookOnUpdateCombat() {
         Hooks.on("updateCombat", (combat, update, options, userId) => {
             HypeTrack._onUpdateCombat(combat, update, options, userId);
@@ -148,8 +148,8 @@ export default class Conductor {
     }
 
     /**
-     * Delete Combat Hook
-     */
+    * Delete Combat Hook
+    */
     static _hookOnDeleteCombat() {
         Hooks.on("deleteCombat", (combat, options, userId) => {
             HypeTrack._onDeleteCombat(combat, options, userId);
@@ -158,8 +158,8 @@ export default class Conductor {
     }
 
     /**
-     * Render Actor SheetsHook
-     */
+    * Render Actor SheetsHook
+    */
     static _hookOnRenderActorSheet() {
         Hooks.on("renderActorSheet", (app, html, data) => {
             HypeTrack._onRenderActorSheet(app, html, data);
@@ -168,8 +168,8 @@ export default class Conductor {
     }
 
     /**
-     * RenderChatMessage Hook
-     */
+    * RenderChatMessage Hook
+    */
     static _hookOnRenderChatMessage() {
         Hooks.on("renderChatMessage", (message, html, data) => {
             ItemTrack._onRenderChatMessage(message, html, data);
@@ -178,8 +178,8 @@ export default class Conductor {
     }
 
     /**
-     * RenderPlaylistDirectory Hook
-     */
+    * RenderPlaylistDirectory Hook
+    */
     static _hookOnRenderPlaylistDirectory() {
         Hooks.on("renderPlaylistDirectory", (app, html, data) => {
             Misc._onRenderPlaylistDirectory(app, html, data);
@@ -187,8 +187,8 @@ export default class Conductor {
     }
 
     /**
-     * Render CombatTrackerConfig Hook
-     */
+    * Render CombatTrackerConfig Hook
+    */
     static _hookOnRenderCombatTrackerConfig() {
         Hooks.on("renderCombatTrackerConfig", (app, html, data) => {
             CombatTrack._onRenderCombatTrackerConfig(app, html, data);
@@ -196,8 +196,8 @@ export default class Conductor {
     }
 
     /**
-     * Render Item Sheet Hook
-     */
+    * Render Item Sheet Hook
+    */
     static _hookOnRenderItemSheet() {
         Hooks.on("renderItemSheet", (app, html, data) => {
             ItemTrack._onRenderItemSheet(app, html, data);
@@ -208,9 +208,9 @@ export default class Conductor {
 }
 
 /**
- * Tap, tap, tap, ahem
- * Shall we begin?
- *
- * Initiates the module
- */
+* Tap, tap, tap, ahem
+* Shall we begin?
+*
+* Initiates the module
+*/
 Conductor.begin();

--- a/maestro.js
+++ b/maestro.js
@@ -156,7 +156,7 @@ export default class Conductor {
             CombatTrack._onDeleteCombat(combat, options, userId);
         });
     }
-    
+
     /**
      * Render Actor SheetsHook
      */
@@ -164,7 +164,7 @@ export default class Conductor {
         Hooks.on("renderActorSheet", (app, html, data) => {
             HypeTrack._onRenderActorSheet(app, html, data);
         });
-       
+
     }
 
     /**
@@ -202,14 +202,15 @@ export default class Conductor {
         Hooks.on("renderItemSheet", (app, html, data) => {
             ItemTrack._onRenderItemSheet(app, html, data);
         });
-        
+
     }
+
 }
 
 /**
  * Tap, tap, tap, ahem
  * Shall we begin?
- * 
+ *
  * Initiates the module
  */
 Conductor.begin();

--- a/modules/config.js
+++ b/modules/config.js
@@ -148,6 +148,7 @@ export const SETTINGS_KEYS = {
             criticalDieFaces: "dieFaces",
             criticalSuccessThreshold: "successThreshold",
             criticalFailureThreshold: "failureThreshold",
+            criticalOnBlindRoll: "criticalOnBlindRoll",
             maestroConfigMenu: "maestroConfigMenu"
         }
     }

--- a/modules/config.js
+++ b/modules/config.js
@@ -11,7 +11,7 @@ export const DEFAULT_CONFIG = {
             },
             templatePath: "./modules/maestro/templates/playlist-select.html"
         }
-       
+
     },
 
     get HypeTrack() {
@@ -27,9 +27,9 @@ export const DEFAULT_CONFIG = {
             },
             templatePath: "./modules/maestro/templates/hype-track-form.html"
         }
-        
+
     },
-    
+
     get ItemTrack() {
         return {
             name: "item-track",
@@ -103,7 +103,7 @@ export const FLAGS = {
         }
     }
 }
-        
+
 
 export const SETTINGS_KEYS = {
     get ItemTrack() {

--- a/modules/config.js
+++ b/modules/config.js
@@ -151,7 +151,11 @@ export const SETTINGS_KEYS = {
             criticalOnBlindRoll: "criticalOnBlindRoll",
             maestroConfigMenu: "maestroConfigMenu"
         }
-    }
+    },
 
-    
+    get PF2eSpecific() {
+      return {
+        enablePF2RulesCriticals: "enablePF2RulesCriticals"
+      }
+    }
 }

--- a/modules/misc.js
+++ b/modules/misc.js
@@ -232,6 +232,11 @@ export function _onRenderChatMessage(message, html, data) {
 function playCriticalSuccessFailure(message) {
     if ( !isFirstGM() || !message.isRoll || !message.isContentVisible ) return;
 
+    // if message is blind and we settings say we shouldn't play sound on critical, early exit
+    if (!game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalOnBlindRoll)
+        && message.blind
+    ) return;
+
     for (const roll of message.rolls) {
         checkRollSuccessFailure(roll);
     }

--- a/modules/misc.js
+++ b/modules/misc.js
@@ -24,7 +24,7 @@ export class MaestroConfigForm extends FormApplication {
             width: 500
         });
     }
-    
+
     /**
      * Provide data to the template
      */
@@ -34,7 +34,7 @@ export class MaestroConfigForm extends FormApplication {
         if (!this.data && criticalSuccessFailureTracks) {
             this.data = criticalSuccessFailureTracks;
         }
-        
+
         return {
             playlists: game.playlists.contents,
             criticalSuccessPlaylist: this.data.criticalSuccessPlaylist,
@@ -43,13 +43,13 @@ export class MaestroConfigForm extends FormApplication {
             criticalFailurePlaylist: this.data.criticalFailurePlaylist,
             criticalFailurePlaylistSounds: this.data.criticalFailurePlaylist ? Playback.getPlaylistSounds(this.data.criticalFailurePlaylist) : null,
             criticalFailureSound: this.data.criticalFailureSound
-        } 
+        }
     }
 
     /**
      * Update on form submit
-     * @param {*} event 
-     * @param {*} formData 
+     * @param {*} event
+     * @param {*} formData
      */
     async _updateObject(event, formData) {
         await game.settings.set(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalSuccessFailureTracks, {
@@ -78,19 +78,19 @@ export class MaestroConfigForm extends FormApplication {
                 this.data.criticalFailurePlaylist = event.target.value;
                 this.render();
             });
-        } 
+        }
     }
 }
 
 /**
  * Adds a new toggle for loop to the playlist controls
- * @param {*} html 
+ * @param {*} html
  */
 function _addPlaylistLoopToggle(html) {
     if (!game.user.isGM) return;
-    
+
     const playlistModeButtons = html.find('[data-action="playlist-mode"]');
-    const loopToggleHtml = 
+    const loopToggleHtml =
         `<a class="sound-control" data-action="playlist-loop" title="${game.i18n.localize("MAESTRO.PLAYLIST-LOOP.ButtonTooltipLoop")}">
             <i class="fas fa-sync"></i>
         </a>`;
@@ -145,7 +145,7 @@ function _addPlaylistLoopToggle(html) {
             game.playlists.get(playlistId).unsetFlag(MAESTRO.MODULE_NAME, MAESTRO.DEFAULT_CONFIG.PlaylistLoop.flagNames.loop);
             button.setAttribute("class", buttonClass.replace(" inactive", ""));
             button.setAttribute("title", game.i18n.localize("MAESTRO.PLAYLIST-LOOP.ButtonTooltipLoop"));
-        } else { 
+        } else {
             game.playlists.get(playlistId).setFlag(MAESTRO.MODULE_NAME, MAESTRO.DEFAULT_CONFIG.PlaylistLoop.flagNames.loop, false);
             button.setAttribute("class", buttonClass.concat(" inactive"));
             button.setAttribute("title", game.i18n.localize("MAESTRO.PLAYLIST-LOOP.ButtonTooltipNoLoop"));
@@ -155,8 +155,8 @@ function _addPlaylistLoopToggle(html) {
 
 /**
  * PreUpdate Playlist Sound handler
- * @param {*} playlist 
- * @param {*} update 
+ * @param {*} playlist
+ * @param {*} update
  * @todo maybe return early if no flag set?
  */
 export function _onPreUpdatePlaylistSound(sound, update, options, userId) {
@@ -188,8 +188,8 @@ export function _onPreUpdatePlaylistSound(sound, update, options, userId) {
         order = playlist.playbackOrder;
     } else {
         order = playlist?.sounds.map(s => s.id);
-    }        
-    
+    }
+
     const previousIdx = order.indexOf(previousSound);
     const playlistloop = playlist.getFlag(MAESTRO.MODULE_NAME, MAESTRO.DEFAULT_CONFIG.PlaylistLoop.flagNames.loop);
 
@@ -197,7 +197,7 @@ export function _onPreUpdatePlaylistSound(sound, update, options, userId) {
     if (previousIdx === (playlist?.sounds?.length - 1) && playlistloop === false) {
         update.playing = false;
         playlist.playing = false;
-    }        
+    }
 }
 
 /**
@@ -213,9 +213,9 @@ export function _onPreCreateChatMessage(message, options, userId) {
 
 /**
  * Render Chat Message handler
- * @param {*} message 
- * @param {*} html 
- * @param {*} data 
+ * @param {*} message
+ * @param {*} html
+ * @param {*} data
  */
 export function _onRenderChatMessage(message, html, data) {
     const enableCriticalSuccessFailureTracks = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.enableCriticalSuccessFailureTracks);
@@ -231,17 +231,17 @@ export function _onRenderChatMessage(message, html, data) {
  */
 function playCriticalSuccessFailure(message) {
     if ( !isFirstGM() || !message.isRoll || !message.isContentVisible ) return;
-    
+
     for (const roll of message.rolls) {
         checkRollSuccessFailure(roll);
     }
-    
+
 }
 
 /**
  * Play a sound for critical success or failure on d20 rolls
  * Adapted from highlightCriticalSuccessFailure in the dnd5e system
- * @param {*} roll 
+ * @param {*} roll
  */
 function checkRollSuccessFailure(roll) {
     // Highlight rolls where the first part is a d20 roll
@@ -265,7 +265,7 @@ function checkRollSuccessFailure(roll) {
     // Get the success/failure criteria
     const successSetting = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalSuccessThreshold);
     const failureSetting = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalFailureThreshold);
-    
+
     const successThreshold = successSetting ?? d.options.critical;
     const failureThreshold = failureSetting ?? d.options.fumble;
 

--- a/modules/misc.js
+++ b/modules/misc.js
@@ -234,7 +234,7 @@ function playCriticalSuccessFailure(message) {
 
     // if message is blind and we settings say we shouldn't play sound on critical, early exit
     if (!game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalOnBlindRoll)
-        && message.blind
+    && message.blind
     ) return;
 
     for (const roll of message.rolls) {
@@ -260,13 +260,6 @@ function checkRollSuccessFailure(roll) {
     const isModifiedRoll = ("success" in d.results[0]) || d.options.marginSuccess || d.options.marginFailure;
     if ( isModifiedRoll ) return;
 
-    // Get the sounds
-    const criticalSuccessFailureTracks = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalSuccessFailureTracks);
-    const criticalSuccessPlaylist = criticalSuccessFailureTracks.criticalSuccessPlaylist;
-    const criticalSuccessSound = criticalSuccessFailureTracks.criticalSuccessSound;
-    const criticalFailurePlaylist = criticalSuccessFailureTracks.criticalFailurePlaylist;
-    const criticalFailureSound = criticalSuccessFailureTracks.criticalFailureSound;
-
     // Get the success/failure criteria
     const successSetting = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalSuccessThreshold);
     const failureSetting = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalFailureThreshold);
@@ -275,10 +268,10 @@ function checkRollSuccessFailure(roll) {
     const failureThreshold = failureSetting ?? d.options.fumble;
 
     // Play relevant sound for successes and failures
-    if ((successThreshold && (d.total >= successThreshold)) && (criticalSuccessPlaylist && criticalSuccessSound)) {
-        Playback.playTrack(criticalSuccessSound, criticalSuccessPlaylist);
-    } else if ((failureThreshold && (d.total <= failureThreshold)) && (criticalFailurePlaylist && criticalFailureSound)) {
-        Playback.playTrack(criticalFailureSound, criticalFailurePlaylist)
+    if ((successThreshold && (d.total >= successThreshold))) {
+        playSuccess();
+    } else if ((failureThreshold && (d.total <= failureThreshold))) {
+        playFailure();
     }
 }
 
@@ -339,6 +332,41 @@ async function _createFailurePlaylist(create) {
     }
     return await Playlist.create({"name": MAESTRO.DEFAULT_CONFIG.Misc.criticalFailurePlaylistName});
 }
+
+/**
+ * Play critical success sound
+ */
+function playSuccess() {
+    playCriticalSound(true)
+}
+
+/**
+ * Play critical failure sound
+ */
+function playFailure() {
+    playCriticalSound(false);
+}
+
+
+/**
+ * Play critical sound depending on success kind.
+ * @param {boolean} isSuccess
+ */
+function playCriticalSound(isSuccess) {
+    const criticalSuccessFailureTracks = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalSuccessFailureTracks);
+    let playlist, sound;
+    if (isSuccess) {
+        playlist = criticalSuccessFailureTracks.criticalSuccessPlaylist;
+        sound = criticalSuccessFailureTracks.criticalSuccessSound;
+    } else {
+        playlist = criticalSuccessFailureTracks.criticalFailurePlaylist;
+        sound = criticalSuccessFailureTracks.criticalFailureSound;
+    }
+    if (playlist && sound) {
+        Playback.playTrack(sound, playlist);
+    }
+}
+
 
 /**
 * Gets the first (sorted by userId) active GM user

--- a/modules/misc.js
+++ b/modules/misc.js
@@ -13,8 +13,8 @@ export class MaestroConfigForm extends FormApplication {
     }
 
     /**
-     * Default Options for this FormApplication
-     */
+    * Default Options for this FormApplication
+    */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             id: "maestro-config",
@@ -26,8 +26,8 @@ export class MaestroConfigForm extends FormApplication {
     }
 
     /**
-     * Provide data to the template
-     */
+    * Provide data to the template
+    */
     getData() {
         const criticalSuccessFailureTracks = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalSuccessFailureTracks);
 
@@ -47,10 +47,10 @@ export class MaestroConfigForm extends FormApplication {
     }
 
     /**
-     * Update on form submit
-     * @param {*} event
-     * @param {*} formData
-     */
+    * Update on form submit
+    * @param {*} event
+    * @param {*} formData
+    */
     async _updateObject(event, formData) {
         await game.settings.set(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalSuccessFailureTracks, {
             criticalSuccessPlaylist: formData["critical-success-playlist"],
@@ -83,17 +83,17 @@ export class MaestroConfigForm extends FormApplication {
 }
 
 /**
- * Adds a new toggle for loop to the playlist controls
- * @param {*} html
- */
+* Adds a new toggle for loop to the playlist controls
+* @param {*} html
+*/
 function _addPlaylistLoopToggle(html) {
     if (!game.user.isGM) return;
 
     const playlistModeButtons = html.find('[data-action="playlist-mode"]');
     const loopToggleHtml =
-        `<a class="sound-control" data-action="playlist-loop" title="${game.i18n.localize("MAESTRO.PLAYLIST-LOOP.ButtonTooltipLoop")}">
-            <i class="fas fa-sync"></i>
-        </a>`;
+    `<a class="sound-control" data-action="playlist-loop" title="${game.i18n.localize("MAESTRO.PLAYLIST-LOOP.ButtonTooltipLoop")}">
+    <i class="fas fa-sync"></i>
+    </a>`;
 
     playlistModeButtons.after(loopToggleHtml);
 
@@ -154,11 +154,11 @@ function _addPlaylistLoopToggle(html) {
 }
 
 /**
- * PreUpdate Playlist Sound handler
- * @param {*} playlist
- * @param {*} update
- * @todo maybe return early if no flag set?
- */
+* PreUpdate Playlist Sound handler
+* @param {*} playlist
+* @param {*} update
+* @todo maybe return early if no flag set?
+*/
 export function _onPreUpdatePlaylistSound(sound, update, options, userId) {
     // skip this method if the playlist sound has already been processed
     if (sound?._maestroSkip) return true;
@@ -201,8 +201,8 @@ export function _onPreUpdatePlaylistSound(sound, update, options, userId) {
 }
 
 /**
- * PreCreate Chat Message handler
- */
+* PreCreate Chat Message handler
+*/
 export function _onPreCreateChatMessage(message, options, userId) {
     const removeDiceSound = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.disableDiceSound);
 
@@ -212,11 +212,11 @@ export function _onPreCreateChatMessage(message, options, userId) {
 }
 
 /**
- * Render Chat Message handler
- * @param {*} message
- * @param {*} html
- * @param {*} data
- */
+* Render Chat Message handler
+* @param {*} message
+* @param {*} html
+* @param {*} data
+*/
 export function _onRenderChatMessage(message, html, data) {
     const enableCriticalSuccessFailureTracks = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.enableCriticalSuccessFailureTracks);
 
@@ -226,9 +226,9 @@ export function _onRenderChatMessage(message, html, data) {
 }
 
 /**
- * Process Critical Success/Failure for a given message
- * @param {*} message
- */
+* Process Critical Success/Failure for a given message
+* @param {*} message
+*/
 function playCriticalSuccessFailure(message) {
     if ( !isFirstGM() || !message.isRoll || !message.isContentVisible ) return;
 
@@ -239,10 +239,10 @@ function playCriticalSuccessFailure(message) {
 }
 
 /**
- * Play a sound for critical success or failure on d20 rolls
- * Adapted from highlightCriticalSuccessFailure in the dnd5e system
- * @param {*} roll
- */
+* Play a sound for critical success or failure on d20 rolls
+* Adapted from highlightCriticalSuccessFailure in the dnd5e system
+* @param {*} roll
+*/
 function checkRollSuccessFailure(roll) {
     // Highlight rolls where the first part is a d20 roll
     if ( !roll.dice.length ) return;
@@ -278,8 +278,8 @@ function checkRollSuccessFailure(roll) {
 }
 
 /**
- * Checks for the presence of the Critical playlist, creates one if none exist
- */
+* Checks for the presence of the Critical playlist, creates one if none exist
+*/
 export async function _checkForCriticalPlaylist() {
     const enabled = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.enableCriticalSuccessFailureTracks);
     const createPlaylist = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.createCriticalSuccessPlaylist);
@@ -296,9 +296,9 @@ export async function _checkForCriticalPlaylist() {
 }
 
 /**
- * Create the Critical playlist if the create param is true
- * @param {Boolean} create - whether or not to create the playlist
- */
+* Create the Critical playlist if the create param is true
+* @param {Boolean} create - whether or not to create the playlist
+*/
 async function _createCriticalPlaylist(create) {
     if (!create) {
         return;
@@ -307,8 +307,8 @@ async function _createCriticalPlaylist(create) {
 }
 
 /**
- * Checks for the presence of the Failure playlist, creates one if none exist
- */
+* Checks for the presence of the Failure playlist, creates one if none exist
+*/
 export async function _checkForFailurePlaylist() {
     const enabled = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.enableCriticalSuccessFailureTracks);
     const createPlaylist = game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.createCriticalFailurePlaylist);
@@ -325,9 +325,9 @@ export async function _checkForFailurePlaylist() {
 }
 
 /**
- * Create the Failure playlist if the create param is true
- * @param {Boolean} create - whether or not to create the playlist
- */
+* Create the Failure playlist if the create param is true
+* @param {Boolean} create - whether or not to create the playlist
+*/
 async function _createFailurePlaylist(create) {
     if (!create) {
         return;
@@ -336,17 +336,17 @@ async function _createFailurePlaylist(create) {
 }
 
 /**
- * Gets the first (sorted by userId) active GM user
- * @returns {User | undefined} the GM user document or undefined if none found
- */
+* Gets the first (sorted by userId) active GM user
+* @returns {User | undefined} the GM user document or undefined if none found
+*/
 export function getFirstActiveGM() {
     return game.users.filter(u => u.isGM && u.active).sort((a, b) => a.id?.localeCompare(b.id)).shift();
 }
 
 /**
- * Checks if the current user is the first active GM user
- * @returns {Boolean} Boolean indicating whether the user is the first active GM or not
- */
+* Checks if the current user is the first active GM user
+* @returns {Boolean} Boolean indicating whether the user is the first active GM or not
+*/
 export function isFirstGM() {
     return game.userId === getFirstActiveGM()?.id;
 }

--- a/modules/misc.js
+++ b/modules/misc.js
@@ -239,6 +239,15 @@ function playCriticalSuccessFailure(message) {
 
     let successCheckFn = checkSuccessOfRoll_system_less;
 
+    // Check if pf2 settings is enable and if message is a PF2e roll message with a rolling actor
+    if (game.settings.get(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.PF2eSpecific.enablePF2RulesCriticals)
+    && message.flags
+    && message.flags.pf2e
+    && message.flags.pf2e.context.dc
+    && message.flags.pf2e.context.outcome) {
+        successCheckFn = checkSuccessOfRoll_pf2e(message);
+    }
+
     for (const roll of message.rolls) {
         checkRollSuccessFailure(roll, successCheckFn);
     }
@@ -297,6 +306,31 @@ function checkSuccessOfRoll_system_less(diceTerm) {
         return {"isCritical":true,"isSuccess":false};
     }
 }
+
+/**
+ * Use pathfinder 2e rules to check for critical success or failure.
+ *
+ * The context of the message already contains the outcome of the roll so we reuse it directly
+ * and don't use the result of the roll.
+ * @param {ChatMessage} message
+ * @returns {((arg0: any) => { isCritical: boolean; isSuccess: boolean; })}
+ */
+function checkSuccessOfRoll_pf2e(message) {
+    let returnValue;
+    switch (message.flags.pf2e.context.outcome) {
+        case "criticalFailure":
+        returnValue = { "isCritical": true, "isSuccess": false };
+        break;
+        case "criticalSuccess":
+        returnValue = { "isCritical": true, "isSuccess": true };
+        break;
+        default:
+        returnValue = { "isCritical": false, "isSuccess": null };
+    }
+
+    return (__) => returnValue;
+}
+
 
 /**
 * Checks for the presence of the Critical playlist, creates one if none exist

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -240,6 +240,15 @@ export const registerModuleSettings = async function() {
         default: 1,
         config: true,
     }),
+
+      game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalOnBlindRoll, {
+        name: "MAESTRO.SETTINGS.CriticalSuccessFailureTracks.criticalOnBlindRollN",
+        hint: "MAESTRO.SETTINGS.CriticalSuccessFailureTracks.criticalOnBlindRollH",
+        scope: "world",
+        type: Boolean,
+        default: true,
+        config: true,
+    }),
     }),
 
     game.settings.registerMenu(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.maestroConfigMenu,{

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -249,6 +249,14 @@ export const registerModuleSettings = async function() {
         default: true,
         config: true,
     }),
+
+    game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.PF2eSpecific.enablePF2RulesCriticals, {
+        name: "MAESTRO.SETTINGS.PF2eSpecific.enableN",
+        hint: "MAESTRO.SETTINGS.PF2eSpecific.enableH",
+        scope: "world",
+        type: Boolean,
+        default: false,
+        config: true,
     }),
 
     game.settings.registerMenu(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.maestroConfigMenu,{

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -1,3 +1,4 @@
+import Conductor from "../maestro.js";
 import * as MAESTRO from "./config.js";
 import { _checkForCriticalPlaylist, _checkForFailurePlaylist, MaestroConfigForm } from "./misc.js";
 
@@ -30,7 +31,6 @@ export const registerModuleSettings = async function() {
         type: Boolean,
         default: false,
         config: true,
-        onChange: async s => {}
     }),
 
     /* -------------------------------------------- */
@@ -44,9 +44,6 @@ export const registerModuleSettings = async function() {
         type: Boolean,
         default: false,
         config: true,
-        onChange: s => {
-            
-        }
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.ItemTrack.createPlaylist, {
@@ -72,9 +69,6 @@ export const registerModuleSettings = async function() {
         type: String,
         default: "data-item-id",
         config: true,
-        onChange: s => {
-            
-        }
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.ItemTrack.deletedItems, {
@@ -84,7 +78,6 @@ export const registerModuleSettings = async function() {
         type: Object,
         default: {},
         config: false,
-        onChange: s => {}
     }),
 
     /* -------------------------------------------- */
@@ -98,9 +91,6 @@ export const registerModuleSettings = async function() {
         type: Boolean,
         default: false,
         config: true,
-        onChange: s => {
-            
-        }
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.CombatTrack.createPlaylist, {
@@ -125,9 +115,6 @@ export const registerModuleSettings = async function() {
         scope: "world",
         type: String,
         default: "",
-        onChange: s => {
-            
-        }
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.CombatTrack.defaultTrack, {
@@ -136,9 +123,6 @@ export const registerModuleSettings = async function() {
         scope: "world",
         type: String,
         default: "",
-        onChange: s => {
-            
-        }
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.CombatTrack.pauseOthers, {
@@ -148,7 +132,6 @@ export const registerModuleSettings = async function() {
         type: Boolean,
         default: false,
         config: true,
-        onChange: async s => {}
     }),
 
     /* -------------------------------------------- */
@@ -161,9 +144,6 @@ export const registerModuleSettings = async function() {
         scope: "world",
         type: String,
         default: "",
-        onChange: s => {
-
-        }
     }),
 
     /* -------------------------------------------- */
@@ -177,9 +157,6 @@ export const registerModuleSettings = async function() {
         type: Boolean,
         default: false,
         config: true,
-        onChange: s => {
-
-        }
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.enableCriticalSuccessFailureTracks, {
@@ -189,9 +166,6 @@ export const registerModuleSettings = async function() {
         type: Boolean,
         default: false,
         config: true,
-        onChange: s => {
-
-        }
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.createCriticalSuccessPlaylist, {
@@ -238,9 +212,6 @@ export const registerModuleSettings = async function() {
             criticalFailureSound: ""
         },
         config: false,
-        onChange: s => {
-
-        }
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalDieFaces, {
@@ -250,7 +221,6 @@ export const registerModuleSettings = async function() {
         type: Number,
         default: 20,
         config: true,
-        onChange: s => {}
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalSuccessThreshold, {
@@ -260,7 +230,6 @@ export const registerModuleSettings = async function() {
         type: Number,
         default: 20,
         config: true,
-        onChange: s => {}
     }),
 
     game.settings.register(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.criticalFailureThreshold, {
@@ -270,7 +239,7 @@ export const registerModuleSettings = async function() {
         type: Number,
         default: 1,
         config: true,
-        onChange: s => {}
+    }),
     }),
 
     game.settings.registerMenu(MAESTRO.MODULE_NAME, MAESTRO.SETTINGS_KEYS.Misc.maestroConfigMenu,{


### PR DESCRIPTION
I took the liberty to do a bit of cleanup and reformat first. I couldn't find if there a specific code format style for maestro so I used the default one coming with visual studio code (no trailing space, indent using 4 spaces).

First new feature add a settings to be able to play sound on blind rolls or not. 
By default, I kept the existing behavior so it should play sound on every rolls.
 

Second new feature add a way to detect critical success and failure as per pathfinder 2e rules.

If the game world is not using pf2e system, enabling that feature won't do anything.
By default, the setting is disabled to keep the same behavior as before.

It should fix https://github.com/death-save/maestro/issues/156


I thought about moving "the play sound on critical" features and related functions out of `misc.js` to a `critical.js`, what do you think?